### PR TITLE
Adds deletion functionality to signups

### DIFF
--- a/CMPT395/static/css/calendar.css
+++ b/CMPT395/static/css/calendar.css
@@ -155,3 +155,13 @@
 .time-slot .event {
   border-top: dotted black 1px;
 }
+
+.event .fa-trash:hover {
+  color: red;
+}
+
+.event .signup-info {
+  text-align: center;
+  padding: 0;
+  margin: 0;
+}

--- a/CMPT395/templates/calendar.html
+++ b/CMPT395/templates/calendar.html
@@ -37,7 +37,7 @@
       </div>
       
       <section id="signup_headers">
-        <h3 id="js-signup-day" class="signup-title">Default</h5>
+        <h3 id="js-signup-day" class="signup-title">Default</h3>
         <h5 id="js-signup-date" class="signup-title">Default</h5>
       </section>
       
@@ -46,7 +46,7 @@
         <fieldset>
           <legend>Sign-up Information:</legend>
           {{ view.signup_form.as_p }}
-	  <input id="id_classroom" type="hidden" name="classroom"/>
+	        <input id="id_classroom" type="hidden" name="classroom"/>
           <input id="js-signup-hidden-date" type="hidden" name="day" value="Default"/>
           <button type="submit">Submit</button>
         </fieldset>
@@ -95,8 +95,17 @@
                  {% if signup.date == day.1 %}
                    {% if signup.start_time >= slot.start and signup.end_time <= slot.end %}
                      <section class="event">
-                       <p class="signup-info">{{ signup.volunteer }}</p>
-                       <p class="signup-info">{% format_time signup.start_time %} - {% format_time signup.end_time %}</p>
+                       {% user_match signup.volunteer view as match %}
+                       {% if match %}
+                         <form method="POST">
+                           {% csrf_token %}
+                           <button name="delete-signup" class="fa fa-trash" value="{{ signup.signupID }}"></button>
+                         </form>
+                        {% endif %}
+                       <section class="signup-info">
+                         <p>{{ signup.volunteer }}</p>
+                         <p>{% format_time signup.start_time %} - {% format_time signup.end_time %}</p>
+                       </section>
                      </section><!-- End event -->
                    {% endif %}
                  {% endif %}

--- a/CMPT395/weeklyCalendar/templatetags/calendar_tags.py
+++ b/CMPT395/weeklyCalendar/templatetags/calendar_tags.py
@@ -16,3 +16,10 @@ def comp(str1, str2):
     return "true"
   else:
     return "false"
+
+@register.simple_tag
+def user_match(volunteer, view):
+  if volunteer.family.user == view.request.user:
+    return True
+  else:
+    return False

--- a/CMPT395/weeklyCalendar/views.py
+++ b/CMPT395/weeklyCalendar/views.py
@@ -46,6 +46,10 @@ class WeeklyCalendarView(TemplateView):
       date_raw = request.POST.get("next-week").split('-')
       date = dt.date(int(date_raw[0]), int(date_raw[1]), int(date_raw[2])) + dt.timedelta(7)
       self.date_and_name = self.pair_date_name(self.WEEK_DAYS, self.get_week(date))
+    
+    elif 'delete-signup' in request.POST:
+      sid = request.POST.get("delete-signup")
+      SignUp.objects.get(signupID=sid).delete()
 
     else:
       form = self.signup_form(request.POST)


### PR DESCRIPTION
Signups belonging to the currently logged in family can be deleted from the calendar by clicking the garbage icon above the signup.
The signup id is stored in as the value of the delete button on each signup which belongs to the current family